### PR TITLE
Hiding initial exception message with default fix.

### DIFF
--- a/lib/xero-ruby/api_error.rb
+++ b/lib/xero-ruby/api_error.rb
@@ -31,6 +31,7 @@ module XeroRuby
           instance_variable_set "@#{k}", v
         end
       else
+        @message = arg
         super arg
       end
     end


### PR DESCRIPTION
Currently when the ApiError is used with simple string message as input the original message is overwritten with default "Error message: the server returns an error".

Which is pretty misleading e.g by timeout errors (https://github.com/XeroAPI/xero-ruby/blob/78fc8630b21c9fba9af4442122c46b8badc79b1b/lib/xero-ruby/api_client.rb#L175):

```
      begin
        response = connection.public_send(http_method.to_sym.downcase) do |req|
          build_request(http_method, path, req, opts)
        end

        if @config.debugging
          @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
        end

        unless response.success?
          if response.status == 0
            # Errors from libcurl will be made visible here
            fail ApiError.new(:code => 0,
                              :message => response.return_message)
          else
            fail ApiError.new(:code => response.status,
                              :response_headers => response.headers,
                              :response_body => response.body),
                 response.reason_phrase
          end
        end
      rescue Faraday::TimeoutError
        fail ApiError.new('Connection timed out')
      end
```

This message would be overwritten:
```
fail ApiError.new('Connection timed out')
```

Thanks.